### PR TITLE
Update Twitch embeds to use https

### DIFF
--- a/modules/class.streamchatmodule.php
+++ b/modules/class.streamchatmodule.php
@@ -21,7 +21,7 @@ class StreamChatModule extends Gdn_Module {
       else {
         switch($this->_Stream->Service) {
           case 'twitch':
-            return '<iframe frameborder="0" scrolling="no" id="chat_embed" src="http://twitch.tv/chat/embed?channel='
+            return '<iframe frameborder="0" scrolling="no" id="chat_embed" src="https://twitch.tv/chat/embed?channel='
                     . $this->_Stream->AccountID
                     . '&popout_chat=true" height="500" width="300"></iframe>';
           case 'justin':

--- a/views/twitch-details.php
+++ b/views/twitch-details.php
@@ -3,12 +3,12 @@ $Stream = $this->Data('Stream');
 
 echo Wrap($this->Title, 'h1');
 
-echo '<object type="application/x-shockwave-flash" height="378" width="620" id="live_embed_player_flash" data="http://www.twitch.tv/widgets/live_embed_player.swf?channel='
+echo '<object type="application/x-shockwave-flash" height="378" width="620" id="live_embed_player_flash" data="https://www.twitch.tv/widgets/live_embed_player.swf?channel='
         . $Stream->AccountID
         . '" bgcolor="#000000">'
         . '<param name="allowFullScreen" value="true" />'
         . '<param name="allowScriptAccess" value="always" />'
         . '<param name="allowNetworking" value="all" />'
-        . '<param name="movie" value="http://www.twitch.tv/widgets/live_embed_player.swf" />'
+        . '<param name="movie" value="https://www.twitch.tv/widgets/live_embed_player.swf" />'
         . '<param name="flashvars" value="hostname=www.twitch.tv&channel=' . $Stream->AccountID . '&auto_play=true&start_volume=25" />'
         . '</object>';


### PR DESCRIPTION
Twitch now supports using https for their embeds. These simple changes allow the embeds to show up on Vanilla installs under https.
